### PR TITLE
Add a node_blacklist of nodes containing the Text node to avoid

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -26,5 +26,5 @@ jobs:
         pyflakes .
     - name: Test with pytest
       run: |
-        pip install pytest pytest-doctestplus
+        pip install pytest pytest-doctestplus sphinx-testing
         pytest

--- a/.gitignore
+++ b/.gitignore
@@ -64,7 +64,7 @@ instance/
 .scrapy
 
 # Sphinx documentation
-docs/_build/
+_build/
 
 # PyBuilder
 target/

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,16 @@
+===========
+ Changelog
+===========
+
+1.1 (2019-09-17)
+================
+
+- Allow ``$math$`` in more places.
+- Add the configuration variable ``math_dollar_node_blacklist`` to configure
+  which docutils nodes should not have ``$math$`` replaced.
+- Add tests for the extension part of the code.
+
+1.0 (2019-09-16)
+================
+
+Initial release.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,8 @@
 - Add the configuration variable ``math_dollar_node_blacklist`` to configure
   which docutils nodes should not have ``$math$`` replaced.
 - Add tests for the extension part of the code.
+- Add ``math_dollar_debug`` configuration options and ``MATH_DOLLAR_DEBUG``
+  environment variable to print out debug info on when ``$math$`` is skipped.
 
 1.0 (2019-09-16)
 ================

--- a/README.rst
+++ b/README.rst
@@ -65,6 +65,9 @@ Note that configuring this variable replaces the default, so it is recommended
 to always include the above default values (``NODE_BLACKLIST``) in addition to
 additional nodes.
 
+To debug which nodes are skipped, set the environment variable
+``MATH_DOLLAR_DEBUG=1`` or set ``math_dollar_debug = True`` in ``conf.py``.
+
 If you feel a node should always be part of the default blacklist, please make
 a `pull request <https://github.com/sympy/sphinx-math-dollar/pull/7>`_.
 

--- a/README.rst
+++ b/README.rst
@@ -33,6 +33,41 @@ The extension will also work with docstrings when combined with the
 <https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html>`_
 extension.
 
+Configuration
+=============
+
+sphinx-math-dollar uses a blacklist to determine which `docutils nodes
+<http://docutils.sourceforge.net/docs/ref/doctree.html>`_ should not be
+parsed. The default blacklist is
+
+.. code::
+
+   (FixedTextElement, literal, math)
+
+``FixedTextElement`` covers the `Simple Body Elements
+<http://docutils.sourceforge.net/docs/ref/doctree.html>`_ nodes.
+
+Any docutils node that is contained in a blacklisted node or a subclass of a
+blacklisted node will not have ``$math$`` parsed as LaTeX.
+
+You can modify this by setting ``math_dollar_node_blacklist`` in ``conf.py``.
+For example, to also prevent ``$math$`` from rendering in `headers nodes
+<http://docutils.sourceforge.net/docs/ref/doctree.html#header>`_, add
+
+.. code:: python
+
+   from sphinx_math_dollar import NODE_BLACKLIST
+   from docutils.nodes import header
+
+   math_dollar_node_blacklist = NODE_BLACKLIST + (header,)
+
+Note that configuring this variable replaces the default, so it is recommended
+to always include the above default values (``NODE_BLACKLIST``) in addition to
+additional nodes.
+
+If you feel a node should always be part of the default blacklist, please make
+a `pull request <https://github.com/sympy/sphinx-math-dollar/pull/7>`_.
+
 License
 =======
 

--- a/README.rst
+++ b/README.rst
@@ -69,7 +69,7 @@ To debug which nodes are skipped, set the environment variable
 ``MATH_DOLLAR_DEBUG=1`` or set ``math_dollar_debug = True`` in ``conf.py``.
 
 If you feel a node should always be part of the default blacklist, please make
-a `pull request <https://github.com/sympy/sphinx-math-dollar/pull/7>`_.
+a `pull request <https://github.com/sympy/sphinx-math-dollar>`_.
 
 License
 =======

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,0 +1,1 @@
+.. include:: ../CHANGELOG.rst

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,3 +63,5 @@ html_theme = 'alabaster'
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 # html_static_path = ['_static']
+
+master_doc = 'index'

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,3 +8,5 @@
 .. toctree::
    :maxdepth: 2
    :caption: Contents:
+
+   changelog

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
 addopts = --doctest-modules
+norecursedirs = test-build

--- a/sphinx_math_dollar/__init__.py
+++ b/sphinx_math_dollar/__init__.py
@@ -1,7 +1,7 @@
 from .math_dollar import split_dollars
-from .extension import setup
+from .extension import setup, NODE_BLACKLIST
 
-__all__ = ['split_dollars', 'setup']
+__all__ = ['split_dollars', 'setup', 'NODE_BLACKLIST']
 
 from ._version import get_versions
 __version__ = get_versions()['version']

--- a/sphinx_math_dollar/extension.py
+++ b/sphinx_math_dollar/extension.py
@@ -3,7 +3,6 @@ from .math_dollar import split_dollars
 from docutils.nodes import GenericNodeVisitor, Text, math, FixedTextElement, literal
 from docutils.transforms import Transform
 
-# Note: if the default value here is updated, also update the READMEg
 NODE_BLACKLIST = node_blacklist = (FixedTextElement, literal, math)
 
 class MathDollarReplacer(GenericNodeVisitor):

--- a/sphinx_math_dollar/extension.py
+++ b/sphinx_math_dollar/extension.py
@@ -3,7 +3,8 @@ from .math_dollar import split_dollars
 from docutils.nodes import GenericNodeVisitor, Text, math, FixedTextElement, literal
 from docutils.transforms import Transform
 
-NODE_BLACKLIST = node_blacklist = (FixedTextElement, literal)
+# Note: if the default value here is updated, also update the READMEg
+NODE_BLACKLIST = node_blacklist = (FixedTextElement, literal, math)
 
 class MathDollarReplacer(GenericNodeVisitor):
     def default_visit(self, node):

--- a/sphinx_math_dollar/extension.py
+++ b/sphinx_math_dollar/extension.py
@@ -3,7 +3,7 @@ from .math_dollar import split_dollars
 from docutils.nodes import GenericNodeVisitor, Text, math, FixedTextElement, literal
 from docutils.transforms import Transform
 
-node_blacklist = (FixedTextElement, literal)
+NODE_BLACKLIST = node_blacklist = (FixedTextElement, literal)
 
 class MathDollarReplacer(GenericNodeVisitor):
     def default_visit(self, node):
@@ -36,5 +36,12 @@ class TransformMath(Transform):
     def apply(self, **kwargs):
         self.document.walk(MathDollarReplacer(self.document))
 
+def config_inited(app, config):
+    global node_blacklist
+    node_blacklist = config.math_dollar_node_blacklist
+
 def setup(app):
     app.add_transform(TransformMath)
+    app.add_config_value('math_dollar_node_blacklist', NODE_BLACKLIST, 'env')
+
+    app.connect('config-inited', config_inited)

--- a/sphinx_math_dollar/extension.py
+++ b/sphinx_math_dollar/extension.py
@@ -1,14 +1,16 @@
 from .math_dollar import split_dollars
 
-from docutils.nodes import GenericNodeVisitor, Text, math, paragraph
+from docutils.nodes import GenericNodeVisitor, Text, math, FixedTextElement, literal
 from docutils.transforms import Transform
+
+node_blacklist = (FixedTextElement, literal)
 
 class MathDollarReplacer(GenericNodeVisitor):
     def default_visit(self, node):
         return node
 
     def visit_Text(self, node):
-        if not isinstance(node.parent, paragraph):
+        if isinstance(node.parent, node_blacklist):
             return
         data = split_dollars(node.rawsource)
         nodes = []

--- a/sphinx_math_dollar/extension.py
+++ b/sphinx_math_dollar/extension.py
@@ -10,8 +10,11 @@ class MathDollarReplacer(GenericNodeVisitor):
         return node
 
     def visit_Text(self, node):
-        if isinstance(node.parent, node_blacklist):
-            return
+        parent = node.parent
+        while parent:
+            if isinstance(parent, node_blacklist):
+                return
+            parent = parent.parent
         data = split_dollars(node.rawsource)
         nodes = []
         has_math = False

--- a/sphinx_math_dollar/tests/test-build/Makefile
+++ b/sphinx_math_dollar/tests/test-build/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/sphinx_math_dollar/tests/test-build/conf.py
+++ b/sphinx_math_dollar/tests/test-build/conf.py
@@ -57,3 +57,5 @@ html_theme = 'alabaster'
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
+
+master_doc = 'index'

--- a/sphinx_math_dollar/tests/test-build/conf.py
+++ b/sphinx_math_dollar/tests/test-build/conf.py
@@ -12,7 +12,7 @@
 #
 import os
 import sys
-sys.path.insert(0, os.path.abspath('../..'))
+sys.path.insert(0, os.path.abspath('../../..'))
 
 
 # -- Project information -----------------------------------------------------

--- a/sphinx_math_dollar/tests/test-build/conf.py
+++ b/sphinx_math_dollar/tests/test-build/conf.py
@@ -1,0 +1,52 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+import os
+import sys
+sys.path.insert(0, os.path.abspath('../..'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'sphinx-math-dollar test build'
+copyright = '2019, author'
+author = 'author'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'alabaster'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']

--- a/sphinx_math_dollar/tests/test-build/conf.py
+++ b/sphinx_math_dollar/tests/test-build/conf.py
@@ -14,6 +14,12 @@ import os
 import sys
 sys.path.insert(0, os.path.abspath('../../..'))
 
+# Test configuration
+
+from docutils.nodes import list_item
+from sphinx_math_dollar import NODE_BLACKLIST
+
+math_dollar_node_blacklist = NODE_BLACKLIST + (list_item,)
 
 # -- Project information -----------------------------------------------------
 

--- a/sphinx_math_dollar/tests/test-build/conf.py
+++ b/sphinx_math_dollar/tests/test-build/conf.py
@@ -28,6 +28,7 @@ author = 'author'
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    'sphinx_math_dollar',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/sphinx_math_dollar/tests/test-build/index.rst
+++ b/sphinx_math_dollar/tests/test-build/index.rst
@@ -19,3 +19,9 @@ a definition list with $math$
 .. raw:: html
 
    $nomath$
+
+..
+   $nomath$ in a comment
+
+
+No double math :math:`$nomath$`

--- a/sphinx_math_dollar/tests/test-build/index.rst
+++ b/sphinx_math_dollar/tests/test-build/index.rst
@@ -1,0 +1,21 @@
+For this test, $math$ should render as math and ``$nomath$`` should not.
+
+====================
+ $math$ in a header
+====================
+
+``$nomath$`` in code
+
+>>> print("$nomath$")
+$nomath$
+
+a definition list with $math$
+    some $math$
+
+.. code::
+
+   $nomath$
+
+.. raw:: html
+
+   $nomath$

--- a/sphinx_math_dollar/tests/test-build/index.rst
+++ b/sphinx_math_dollar/tests/test-build/index.rst
@@ -25,3 +25,9 @@ a definition list with $math$
 
 
 No double math :math:`$nomath$`
+
+List items are manually disabled in the blacklist in conf.py
+
+1. $nomath$
+
+* $nomath$

--- a/sphinx_math_dollar/tests/test-build/make.bat
+++ b/sphinx_math_dollar/tests/test-build/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.http://sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/sphinx_math_dollar/tests/test_extension.py
+++ b/sphinx_math_dollar/tests/test_extension.py
@@ -1,0 +1,21 @@
+import os
+
+from sphinx_testing import with_app
+
+@with_app(buildername='html', srcdir=os.path.join(os.path.dirname(__file__), 'test-build'),
+          copy_srcdir_to_tmpdir=True)
+def _test_sphinx_build(app, status, warning):
+    app.build()
+    html = (app.outdir/'index.html').read_text()
+
+    assert r"\(math\)" in html
+    assert "$nomath$" in html
+
+    assert "$math$" not in html
+    assert r"\(nomath\)" not in html
+
+    assert not status.read()
+    assert not warning.read()
+
+def test_sphinx_build():
+    _test_sphinx_build()


### PR DESCRIPTION
Instead of only allowing paragraph, we need to have a blacklist, as text
containing math is often in nodes other than paragraph, such as a listing
node. Instead, we blacklist nodes we definitely don't want to render as math.

Fixes #6.