### PR TITLE
Disable rebuilding when the node blacklist changes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,14 @@
  Changelog
 ===========
 
+1.1.1 (2019-09-30)
+==================
+
+- Fix a bug where the extension would force a full rebuild every time. Note
+  that the ``math_dollar_node_blacklist`` config value now no longer
+  automatically triggers a rebuild when it is changed, as it is impossible to
+  do so without rebuilding every time.
+
 1.1 (2019-09-17)
 ================
 

--- a/sphinx_math_dollar/extension.py
+++ b/sphinx_math_dollar/extension.py
@@ -54,7 +54,9 @@ def config_inited(app, config):
 
 def setup(app):
     app.add_transform(TransformMath)
-    app.add_config_value('math_dollar_node_blacklist', NODE_BLACKLIST, 'env')
+    # We can't force a rebuild here because it will always appear different
+    # since the tuple contains classes
+    app.add_config_value('math_dollar_node_blacklist', NODE_BLACKLIST, '')
     app.add_config_value('math_dollar_debug', DEBUG, '')
 
     app.connect('config-inited', config_inited)


### PR DESCRIPTION
It will appear to change every time, because it is a tuple of classes. There
doesn't seem to be a way to work around this, so we just disable rebuilding
for now.

Fixes #10.