### PR TITLE
Add support for double dollar signs for display math

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
  Changelog
 ===========
 
+1.2 (???)
+=========
+
+- Add support for double dollar signs for display math.
+
 1.1.1 (2019-09-30)
 ==================
 

--- a/README.rst
+++ b/README.rst
@@ -22,6 +22,17 @@ Then in your ``conf.py``, add ``'sphinx_math_dollar'`` to your extensions list:
 
    extensions = ['sphinx_math_dollar', 'sphinx.ext.mathjax']
 
+   mathjax_config = {
+       'tex2jax': {
+           'inlineMath': [ ["\\(","\\)"] ],
+           'displayMath': [["\\[","\\]"] ],
+       },
+   }
+
+
+The ``mathjax_config`` is needed to prevent MathJax from parsing dollar signs
+which are ignored by the extension because they should not be parsed as math.
+
 You will now be able to use dollar signs for math, like ``$\int\sin(x)\,dx$``,
 which will produce $\int\sin(x)\,dx$. You can also use double dollar signs for
 display math, like ``$$\int\sin(x)\,dx$$``, which produces $$\int\sin(x)\,dx$$

--- a/README.rst
+++ b/README.rst
@@ -23,10 +23,11 @@ Then in your ``conf.py``, add ``'sphinx_math_dollar'`` to your extensions list:
    extensions = ['sphinx_math_dollar', 'sphinx.ext.mathjax']
 
 You will now be able to use dollar signs for math, like ``$\int\sin(x)\,dx$``,
-which will produce $\int\sin(x)\,dx$ (if you are reading this on GitHub, look
-at the version built by Sphinx `here
+which will produce $\int\sin(x)\,dx$. You can also use double dollar signs for
+display math, like ``$$\int\sin(x)\,dx$$``, which produces $$\int\sin(x)\,dx$$
+(if you are reading this on GitHub, look at the version built by Sphinx `here
 <https://www.sympy.org/sphinx-math-dollar/>`_). The usual Sphinx ``:math:``
-directive will also continue to work.
+and ``.. math::`` directives will also continue to work.
 
 The extension will also work with docstrings when combined with the
 `sphinx.ext.autodoc

--- a/sphinx_math_dollar/extension.py
+++ b/sphinx_math_dollar/extension.py
@@ -4,7 +4,7 @@ import sys
 
 from .math_dollar import split_dollars
 
-from docutils.nodes import GenericNodeVisitor, Text, math, FixedTextElement, literal
+from docutils.nodes import GenericNodeVisitor, Text, math, math_block, FixedTextElement, literal
 from docutils.transforms import Transform
 
 NODE_BLACKLIST = node_blacklist = (FixedTextElement, literal, math)
@@ -32,6 +32,12 @@ class MathDollarReplacer(GenericNodeVisitor):
                 nodes.append(math(text, Text(text)))
             elif typ == "text":
                 nodes.append(Text(text))
+            elif typ == "display math":
+                has_math = True
+                new_node = math_block(text, Text(text))
+                new_node.attributes.setdefault('nowrap', False)
+                new_node.attributes.setdefault('number', None)
+                nodes.append(new_node)
             else:
                 raise ValueError("Unrecognized type from split_dollars %r" % typ)
         if has_math:

--- a/sphinx_math_dollar/math_dollar.py
+++ b/sphinx_math_dollar/math_dollar.py
@@ -49,7 +49,7 @@ def split_dollars(text):
     # TODO: This will false positive if the {} are not themselves in math
     text = re.sub(r"({[^{}$]*\$[^{}$]*\$[^{}]*})", repl, text)
     # matches $...$
-    dollars = re.compile(r"(?<!\$)(?<!\\)\$([^\$ ](?:(?<=\\)\$|[^\$])*?)(?<!\\)\$")
+    dollars = re.compile(r"(?<!\$)(?<!\\)\$(\$)?([^\$ ](?:(?<=\\)\$|[^\$])*?)(?<!\\)\$(?(1)\$|)")
     res = []
     start = 0
     end = len(text)
@@ -63,10 +63,14 @@ def split_dollars(text):
 
     for m in dollars.finditer(text):
         text_fragment = text[start:m.start()]
-        math_fragment = m.group(1)
+        math_fragment = m.group(2)
+        double_dollar = m.group(1)
         start = m.end()
         _add_fragment(text_fragment, 'text')
-        _add_fragment(math_fragment, 'math')
+        if double_dollar:
+            _add_fragment(math_fragment, 'display math')
+        else:
+            _add_fragment(math_fragment, 'math')
     _add_fragment(text[start:end], 'text')
 
     return res

--- a/sphinx_math_dollar/tests/test-build/conf.py
+++ b/sphinx_math_dollar/tests/test-build/conf.py
@@ -59,3 +59,10 @@ html_theme = 'alabaster'
 html_static_path = ['_static']
 
 master_doc = 'index'
+
+mathjax_config = {
+    'tex2jax': {
+        'inlineMath': [ ["\\(","\\)"] ],
+        'displayMath': [["\\[","\\]"] ],
+    },
+}

--- a/sphinx_math_dollar/tests/test-build/index.rst
+++ b/sphinx_math_dollar/tests/test-build/index.rst
@@ -1,35 +1,60 @@
 For this test, $math$ should render as math and ``$nomath$`` should not.
+$$displaymath$$ should render as display math (TODO: Some of these don't
+actually make sense for display math)
 
 ====================
  $math$ in a header
 ====================
 
+============================
+ $$displaymath$$ in a header
+============================
+
 ``$nomath$`` in code
+``$$nomath$$``
 
 >>> print("$nomath$")
 $nomath$
+>>> print("$$nomath$$")
+$$nomath$$
 
 a definition list with $math$
     some $math$
 
+a definition list with $$displaymath$$
+    some $$displaymath$$
+
 .. code::
 
    $nomath$
+   $$nomath$$
 
 .. raw:: html
 
    $nomath$
+   $$nomath$$
 
 ..
    $nomath$ in a comment
+   $$nomath$$
 
 
-No double math :math:`$nomath$`
+No double math :math:`$nomath$`, :math:`$$nomath$$`
 
-No double dollar signs (will change in the future) $$nomath$$.
+.. math::
+   $nomath$
+
+.. math::
+   $$nomath$$
+
+Double dollar signs $$displaymath$$.
 
 List items are manually disabled in the blacklist in conf.py
 
 1. $nomath$
 
+2. $$nomath$$
+
 * $nomath$
+
+* $$nomath$$

--- a/sphinx_math_dollar/tests/test_extension.py
+++ b/sphinx_math_dollar/tests/test_extension.py
@@ -9,10 +9,17 @@ def _test_sphinx_build(app, status, warning):
     html = (app.outdir/'index.html').read_text()
 
     assert r"\(math\)" in html
+    assert r"\[displaymath\]" in html
     assert "$nomath$" in html
 
     assert "$math$" not in html
+    assert "$$displaymath$$" not in html
+
     assert r"\(nomath\)" not in html
+    assert r"\(displaymath\)" not in html
+
+    assert r"\[math\]" not in html
+    assert r"\[nomath\]" not in html
 
     assert not status.read()
     assert not warning.read()

--- a/sphinx_math_dollar/tests/test_math_dollar.py
+++ b/sphinx_math_dollar/tests/test_math_dollar.py
@@ -43,3 +43,15 @@ def test_split_dollars():
     assert split_dollars(r"$\$13 + \$14$") == [("math", "$13 + $14")]
     assert split_dollars(r"$\$13$.") == [("math", "$13"), ("text", ".")]
     assert split_dollars(r"    $\sin(x)$") == [("text", "    "), ("math", r"\sin(x)")]
+
+    assert split_dollars(r"$$\sin(x)$$") == [("display math", r"\sin(x)")]
+    assert split_dollars(r"$$\sin(x)$") == [("text", r"$$\sin(x)$")]
+    assert split_dollars(r"$$\sin(x)") == [("text", r"$$\sin(x)")]
+    assert split_dollars(r"\$$\sin(x)$$") == [("text", r"$$\sin(x)$$")]
+    assert split_dollars(r"\$\$\sin(x)\$\$") == [("text", r"$$\sin(x)$$")]
+    assert split_dollars(r"$\sin(x)$ and $$\cos(x)$$") == \
+        [
+            ("math", r"\sin(x)"),
+            ("text", " and "),
+            ("display math", r"\cos(x)"),
+        ]


### PR DESCRIPTION
Fixes #4.

Note, it currently allows it in any context where single dollar signs are allowed. But this produces odd results in some cases, like in headers. So maybe we should be more restrictive.

Also, as discussed in #4, it currently parses unclosed dollar signs as text. It might better to raise an error in this case, and require them to be escaped. 