### PR TITLE
Mark extension as parallel read safe

### DIFF
--- a/sphinx_math_dollar/extension.py
+++ b/sphinx_math_dollar/extension.py
@@ -64,5 +64,6 @@ def setup(app):
     # since the tuple contains classes
     app.add_config_value('math_dollar_node_blacklist', NODE_BLACKLIST, '')
     app.add_config_value('math_dollar_debug', DEBUG, '')
+    app.add_config_value('parallel_read_safe', True, '')
 
     app.connect('config-inited', config_inited)


### PR DESCRIPTION
This pull request marks `sphinx-math-dollar` as parallel read safe.  This way, it will let you use this extension while building apps in parallel.  Here's a reference on [extension metadata](https://www.sphinx-doc.org/en/1.3.1/extdev/index.html#extension-metadata) that describes this configuration setting.