### PR TITLE
Exclude docs from installed packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setuptools.setup(
     description="Sphinx extension to let you write LaTeX math using $$",
     long_description=long_description,
     url="https://github.com/sympy/sphinx-math-dollar/",
-    packages=setuptools.find_packages(),
+    packages=setuptools.find_packages(exclude=["docs"]),
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
Since 2a66b0b694564dc72c58f704e6d5a411898f7132 docs is a package,
when installed, this project installs a top-level "docs" module.
This excludes it, as it was not intentional.

(I've also tried not making docs a package, but the tests failed.)