### PR TITLE
Return metadata in setup

### DIFF
--- a/sphinx_math_dollar/__init__.py
+++ b/sphinx_math_dollar/__init__.py
@@ -1,7 +1,9 @@
+from . import _version
+__version__ = _version.get_versions()['version']
+
+
 from .math_dollar import split_dollars
 from .extension import setup, NODE_BLACKLIST
 
 __all__ = ['split_dollars', 'setup', 'NODE_BLACKLIST']
 
-from . import _version
-__version__ = _version.get_versions()['version']

--- a/sphinx_math_dollar/extension.py
+++ b/sphinx_math_dollar/extension.py
@@ -2,6 +2,7 @@ import os
 import sys
 
 from .math_dollar import split_dollars
+from . import __version__
 
 from docutils.nodes import GenericNodeVisitor, Text, math, math_block, FixedTextElement, literal
 from docutils.transforms import Transform
@@ -67,3 +68,9 @@ def setup(app):
     app.add_config_value('parallel_read_safe', True, '')
 
     app.connect('config-inited', config_inited)
+
+    return {
+        'version': __version__,
+        'parallel_read_safe': True,
+        'parallel_write_safe': True,
+    }


### PR DESCRIPTION
Since version 1.3 of sphinx, the setup can return a dictionary with meta data about the extension.  The details of this metadata are https://www.sphinx-doc.org/en/master/extdev/index.html

This PR adds this metadata.  Importantly this stops a warning from sphinx that the app does not return whether it is parallel (read/write) safe.  My understanding of this app is that it is parallel safe for both, so returned True for both.  

I rearranged the setting of `__version__`, but one could also import `_version` and use directly.   