### PR TITLE
Release 1.3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,19 @@
  Changelog
 ===========
 
+1.3 (2026-02-05)
+=================
+
+- Fix crash when encountering unknown node types. The extension now skips
+  unknown nodes with a warning instead of crashing (@MarelliF).
+- Return metadata in ``setup()`` to improve compatibility with parallel
+  processing (@dabacon).
+- Add ``pyproject.toml`` for modern Python packaging.
+- Migrate CI from Travis CI to GitHub Actions.
+- Add Sphinx 9 compatibility by replacing ``sphinx.testing.path`` with
+  ``pathlib``.
+- Update supported Python versions to 3.11, 3.12, 3.13, 3.14, and PyPy 3.11.
+
 1.2.1 (2022-04-25)
 ==================
 


### PR DESCRIPTION
## Summary
- Add changelog entries for the 1.3 release

## Changes since 1.2.1
- Fix crash when encountering unknown node types (@MarelliF)
- Return metadata in `setup()` for parallel processing compatibility (@dabacon)
- Add `pyproject.toml` for modern Python packaging
- Migrate CI from Travis CI to GitHub Actions
- Add Sphinx 9 compatibility (replace `sphinx.testing.path` with `pathlib`)
- Update supported Python versions to 3.11, 3.12, 3.13, 3.14, and PyPy 3.11

## Test plan
- [ ] CI passes on all Python versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)