### PR TITLE
Add optional error on unmatched dollar delimiters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,5 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+.idea/

--- a/sphinx_math_dollar/math_dollar.py
+++ b/sphinx_math_dollar/math_dollar.py
@@ -76,28 +76,50 @@ def split_dollars(text, *, unmatched="ignore"):
             _add_fragment(math_fragment, 'math')
     _add_fragment(text[start:end], 'text')
 
-    # Detect unmatched unescaped dollars that were NOT part of a valid match
-    # Find every unescaped '$' in the full processed text
-    unescaped_dollars = list(re.finditer(r"(?<!\\)\$", text))
+    def _find_unmatched_dollars(s: str) -> bool:
+        #
+        # Return True if there is an unmatched unescaped $ or $$ delimiter in s.
+        #
+        # Assumes that nested $...$ inside {...} have already been replaced
+        # by placeholders (as done above).
 
-    # Spans are in sorted order because finditer is left-to-right
-    span_i = 0
-    for dm in unescaped_dollars:
-        pos = dm.start()
+        i = 0
+        open_delim = None  # None, "$", or "$$"
 
-        # move span_i forward until span ends after pos
-        while span_i < len(spans) and pos >= spans[span_i][1]:
-            span_i += 1
+        while i < len(s):
+            ch = s[i]
 
-        inside_valid = (
-                span_i < len(spans) and spans[span_i][0] <= pos < spans[span_i][1]
-        )
+            # Skip escaped characters like '\$' or '\x'
+            if ch == "\\":
+                i += 2
+                continue
 
-        if not inside_valid:
-            if not inside_valid:
-                if unmatched == "error":
-                    raise ValueError("Unmatched '$' detected. Escape literal dollars as '\\$'.")
-                # if unmatched == "ignore": do nothing
-                break
+            if ch == "$":
+                # $$ or $
+                if i + 1 < len(s) and s[i + 1] == "$":
+                    delim = "$$"
+                    step = 2
+                else:
+                    delim = "$"
+                    step = 1
+
+                if open_delim is None:
+                    open_delim = delim
+                else:
+                    if open_delim == delim:
+                        open_delim = None
+                    else:
+                        # mismatched open/close ($$ ... $ or $ ... $$)
+                        return True
+
+                i += step
+                continue
+
+            i += 1
+
+        return open_delim is not None
+
+    if unmatched == "error" and _find_unmatched_dollars(text):
+        raise ValueError("Unmatched '$' detected. Escape literal dollars as '\\$'.")
 
     return res

--- a/sphinx_math_dollar/math_dollar.py
+++ b/sphinx_math_dollar/math_dollar.py
@@ -1,6 +1,6 @@
 import re
 
-def split_dollars(text):
+def split_dollars(text, *, unmatched="ignore"):
     r"""
     Split text into text and math segments.
 
@@ -32,7 +32,7 @@ def split_dollars(text):
 
       $f(n) = 0 \text{ if $n$ is prime}$
 
-    Thus the above line would get matched fully as math.
+    Thus, the above line would get matched fully as math.
 
     """
     # This searches for "$blah$" inside a pair of curly braces --
@@ -61,7 +61,10 @@ def split_dollars(text):
         if t:
             res.append((typ, t))
 
+    # Store spans of valid matches
+    spans = []
     for m in dollars.finditer(text):
+        spans.append((m.start(), m.end()))
         text_fragment = text[start:m.start()]
         math_fragment = m.group(2)
         double_dollar = m.group(1)
@@ -72,5 +75,29 @@ def split_dollars(text):
         else:
             _add_fragment(math_fragment, 'math')
     _add_fragment(text[start:end], 'text')
+
+    # Detect unmatched unescaped dollars that were NOT part of a valid match
+    # Find every unescaped '$' in the full processed text
+    unescaped_dollars = list(re.finditer(r"(?<!\\)\$", text))
+
+    # Spans are in sorted order because finditer is left-to-right
+    span_i = 0
+    for dm in unescaped_dollars:
+        pos = dm.start()
+
+        # move span_i forward until span ends after pos
+        while span_i < len(spans) and pos >= spans[span_i][1]:
+            span_i += 1
+
+        inside_valid = (
+                span_i < len(spans) and spans[span_i][0] <= pos < spans[span_i][1]
+        )
+
+        if not inside_valid:
+            if not inside_valid:
+                if unmatched == "error":
+                    raise ValueError("Unmatched '$' detected. Escape literal dollars as '\\$'.")
+                # if unmatched == "ignore": do nothing
+                break
 
     return res

--- a/sphinx_math_dollar/tests/test_math_dollar.py
+++ b/sphinx_math_dollar/tests/test_math_dollar.py
@@ -1,4 +1,5 @@
 from ..math_dollar import split_dollars
+import pytest
 
 def test_split_dollars():
     assert split_dollars("Text") == [("text", "Text")]
@@ -55,3 +56,17 @@ def test_split_dollars():
             ("text", " and "),
             ("display math", r"\cos(x)"),
         ]
+def test_unmatched_dollar_raises():
+    with pytest.raises(ValueError):
+        split_dollars("This costs $12", unmatched="error")  # unmatched
+
+def test_escaped_dollar_ok():
+    assert split_dollars(r"This costs \$12") == [("text", "This costs $12")]
+
+
+def test_unmatched_dollar_error_mode():
+    with pytest.raises(ValueError):
+        split_dollars(r"$\sin(x)", unmatched="error")
+
+def test_escaped_dollar_still_ok():
+    assert split_dollars(r"This costs \$12", unmatched="error") == [("text", "This costs $12")]


### PR DESCRIPTION
This PR adds an optional strict mode to detect unmatched unescaped `$` delimiters.

- Default behavior remains unchanged: unmatched `$` is treated as plain text.
- When `unmatched="error"` is enabled, `split_dollars` raises a clear error suggesting escaping literal dollars as `\$`.
- Added tests covering strict mode behavior and escaped dollars.

Fixes #14.
