### PR TITLE
Add paren bracket delims

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,5 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+.idea/

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@
 - Add Sphinx 9 compatibility by replacing ``sphinx.testing.path`` with
   ``pathlib``.
 - Update supported Python versions to 3.11, 3.12, 3.13, 3.14, and PyPy 3.11.
+- Add support for ``\(...\)`` and ``\[...\]`` math delimiters.
 
 1.2.1 (2022-04-25)
 ==================

--- a/sphinx_math_dollar/math_dollar.py
+++ b/sphinx_math_dollar/math_dollar.py
@@ -76,28 +76,50 @@ def split_dollars(text, *, unmatched="ignore"):
             _add_fragment(math_fragment, 'math')
     _add_fragment(text[start:end], 'text')
 
-    # Detect unmatched unescaped dollars that were NOT part of a valid match
-    # Find every unescaped '$' in the full processed text
-    unescaped_dollars = list(re.finditer(r"(?<!\\)\$", text))
+    def _find_unmatched_dollars(s: str) -> bool:
+        #
+        # Return True if there is an unmatched unescaped $ or $$ delimiter in s.
+        #
+        # Assumes that nested $...$ inside {...} have already been replaced
+        # by placeholders (as done above).
 
-    # Spans are in sorted order because finditer is left-to-right
-    span_i = 0
-    for dm in unescaped_dollars:
-        pos = dm.start()
+        i = 0
+        open_delim = None  # None, "$", or "$$"
 
-        # move span_i forward until span ends after pos
-        while span_i < len(spans) and pos >= spans[span_i][1]:
-            span_i += 1
+        while i < len(s):
+            ch = s[i]
 
-        inside_valid = (
-                span_i < len(spans) and spans[span_i][0] <= pos < spans[span_i][1]
-        )
+            # Skip escaped characters like '\$' or '\x'
+            if ch == "\\":
+                i += 2
+                continue
 
-        if not inside_valid:
-            if not inside_valid:
-                if unmatched == "error":
-                    raise ValueError("Unmatched '$' detected. Escape literal dollars as '\\$'.")
-                # if unmatched == "ignore": do nothing
-                break
+            if ch == "$":
+                # $$ or $
+                if i + 1 < len(s) and s[i + 1] == "$":
+                    delim = "$$"
+                    step = 2
+                else:
+                    delim = "$"
+                    step = 1
+
+                if open_delim is None:
+                    open_delim = delim
+                else:
+                    if open_delim == delim:
+                        open_delim = None
+                    else:
+                        # mismatched open/close ($$ ... $ or $ ... $$)
+                        return True
+
+                i += step
+                continue
+
+            i += 1
+
+        return open_delim is not None
+
+    if unmatched == "error" and _find_unmatched_dollars(text):
+        raise ValueError("Unmatched '$' detected. Escape literal dollars as '\\$'.")
 
     return res

--- a/sphinx_math_dollar/math_dollar.py
+++ b/sphinx_math_dollar/math_dollar.py
@@ -50,6 +50,8 @@ def split_dollars(text, *, unmatched="ignore"):
     text = re.sub(r"({[^{}$]*\$[^{}$]*\$[^{}]*})", repl, text)
     # matches $...$
     dollars = re.compile(r"(?<!\$)(?<!\\)\$(\$)?([^\$ ](?:(?<=\\)\$|[^\$])*?)(?<!\\)\$(?(1)\$|)")
+    paren_inline = re.compile(r"(?<!\\)\\\((.*?)\\\)", re.S)
+    bracket_display = re.compile(r"(?<!\\)\\\[(.*?)\\\]", re.S)
     res = []
     start = 0
     end = len(text)
@@ -63,18 +65,35 @@ def split_dollars(text, *, unmatched="ignore"):
 
     # Store spans of valid matches
     spans = []
+    matches = []
+
+    # Dollar matches: $...$ and $$...$$
     for m in dollars.finditer(text):
         spans.append((m.start(), m.end()))
-        text_fragment = text[start:m.start()]
         math_fragment = m.group(2)
         double_dollar = m.group(1)
-        start = m.end()
-        _add_fragment(text_fragment, 'text')
-        if double_dollar:
-            _add_fragment(math_fragment, 'display math')
-        else:
-            _add_fragment(math_fragment, 'math')
-    _add_fragment(text[start:end], 'text')
+        typ = "display math" if double_dollar else "math"
+        matches.append((m.start(), m.end(), math_fragment, typ))
+
+    # Parenthesis matches: \( ... \)
+    for m in paren_inline.finditer(text):
+        matches.append((m.start(), m.end(), m.group(1), "math"))
+
+    # Bracket matches: \[ ... \]
+    for m in bracket_display.finditer(text):
+        matches.append((m.start(), m.end(), m.group(1), "display math"))
+
+    matches.sort(key=lambda x: x[0])
+
+    start = 0
+    for s, e, frag, typ in matches:
+        if s < start:
+            continue
+        _add_fragment(text[start:s], "text")
+        _add_fragment(frag, typ)
+        start = e
+
+    _add_fragment(text[start:end], "text")
 
     def _find_unmatched_dollars(s: str) -> bool:
         #

--- a/sphinx_math_dollar/math_dollar.py
+++ b/sphinx_math_dollar/math_dollar.py
@@ -1,6 +1,6 @@
 import re
 
-def split_dollars(text):
+def split_dollars(text, *, unmatched="ignore"):
     r"""
     Split text into text and math segments.
 
@@ -32,7 +32,7 @@ def split_dollars(text):
 
       $f(n) = 0 \text{ if $n$ is prime}$
 
-    Thus the above line would get matched fully as math.
+    Thus, the above line would get matched fully as math.
 
     """
     # This searches for "$blah$" inside a pair of curly braces --
@@ -61,7 +61,10 @@ def split_dollars(text):
         if t:
             res.append((typ, t))
 
+    # Store spans of valid matches
+    spans = []
     for m in dollars.finditer(text):
+        spans.append((m.start(), m.end()))
         text_fragment = text[start:m.start()]
         math_fragment = m.group(2)
         double_dollar = m.group(1)
@@ -72,5 +75,29 @@ def split_dollars(text):
         else:
             _add_fragment(math_fragment, 'math')
     _add_fragment(text[start:end], 'text')
+
+    # Detect unmatched unescaped dollars that were NOT part of a valid match
+    # Find every unescaped '$' in the full processed text
+    unescaped_dollars = list(re.finditer(r"(?<!\\)\$", text))
+
+    # Spans are in sorted order because finditer is left-to-right
+    span_i = 0
+    for dm in unescaped_dollars:
+        pos = dm.start()
+
+        # move span_i forward until span ends after pos
+        while span_i < len(spans) and pos >= spans[span_i][1]:
+            span_i += 1
+
+        inside_valid = (
+                span_i < len(spans) and spans[span_i][0] <= pos < spans[span_i][1]
+        )
+
+        if not inside_valid:
+            if not inside_valid:
+                if unmatched == "error":
+                    raise ValueError("Unmatched '$' detected. Escape literal dollars as '\\$'.")
+                # if unmatched == "ignore": do nothing
+                break
 
     return res

--- a/sphinx_math_dollar/tests/test_math_dollar.py
+++ b/sphinx_math_dollar/tests/test_math_dollar.py
@@ -1,4 +1,5 @@
 from ..math_dollar import split_dollars
+import pytest
 
 def test_split_dollars():
     assert split_dollars("Text") == [("text", "Text")]
@@ -55,3 +56,17 @@ def test_split_dollars():
             ("text", " and "),
             ("display math", r"\cos(x)"),
         ]
+def test_unmatched_dollar_raises():
+    with pytest.raises(ValueError):
+        split_dollars("This costs $12", unmatched="error")  # unmatched
+
+def test_escaped_dollar_ok():
+    assert split_dollars(r"This costs \$12") == [("text", "This costs $12")]
+
+
+def test_unmatched_dollar_error_mode():
+    with pytest.raises(ValueError):
+        split_dollars(r"$\sin(x)", unmatched="error")
+
+def test_escaped_dollar_still_ok():
+    assert split_dollars(r"This costs \$12", unmatched="error") == [("text", "This costs $12")]

--- a/sphinx_math_dollar/tests/test_math_dollar.py
+++ b/sphinx_math_dollar/tests/test_math_dollar.py
@@ -70,3 +70,18 @@ def test_unmatched_dollar_error_mode():
 
 def test_escaped_dollar_still_ok():
     assert split_dollars(r"This costs \$12", unmatched="error") == [("text", "This costs $12")]
+
+def test_inline_paren_math():
+    assert split_dollars(r"Hello \(x+1\)") == [("text", "Hello "), ("math", "x+1")]
+
+def test_display_bracket_math():
+    assert split_dollars(r"\[x^2\]") == [("display math", "x^2")]
+
+def test_mixed_delims_order():
+    assert split_dollars(r"A \(x\) B $y$ C") == [
+        ("text", "A "),
+        ("math", "x"),
+        ("text", " B "),
+        ("math", "y"),
+        ("text", " C"),
+    ]


### PR DESCRIPTION
Fixes #5 

Adds support for TeX-style math delimiters \(...\) and \[...\].

Implementation processes all delimiter types in a unified ordered pass
to avoid overlap with existing $ / $$ parsing.

Includes tests for inline, display, escaped, and mixed cases.
